### PR TITLE
Add SLE, VED, XCG and XAD to the ISO 4217 table

### DIFF
--- a/iso4217.go
+++ b/iso4217.go
@@ -85,6 +85,7 @@ var (
 	CUP = CurrencyCode{Code: "CUP", NumericCode: "192", Name: "Cuban Peso", DecimalPlaces: 2}
 	CUC = CurrencyCode{Code: "CUC", NumericCode: "931", Name: "Peso Convertible", DecimalPlaces: 2}
 	ANG = CurrencyCode{Code: "ANG", NumericCode: "532", Name: "Netherlands Antillean Guilder", DecimalPlaces: 2}
+	XCG = CurrencyCode{Code: "XCG", NumericCode: "532", Name: "Caribbean Guilder", DecimalPlaces: 2}
 	CZK = CurrencyCode{Code: "CZK", NumericCode: "203", Name: "Czech Koruna", DecimalPlaces: 2}
 	DKK = CurrencyCode{Code: "DKK", NumericCode: "208", Name: "Danish Krone", DecimalPlaces: 2}
 	DJF = CurrencyCode{Code: "DJF", NumericCode: "262", Name: "Djibouti Franc", DecimalPlaces: 0}
@@ -170,8 +171,10 @@ var (
 	RSD = CurrencyCode{Code: "RSD", NumericCode: "941", Name: "Serbian Dinar", DecimalPlaces: 2}
 	SCR = CurrencyCode{Code: "SCR", NumericCode: "690", Name: "Seychelles Rupee", DecimalPlaces: 2}
 	SLL = CurrencyCode{Code: "SLL", NumericCode: "694", Name: "Leone", DecimalPlaces: 2}
+	SLE = CurrencyCode{Code: "SLE", NumericCode: "925", Name: "Leone", DecimalPlaces: 2}
 	SGD = CurrencyCode{Code: "SGD", NumericCode: "702", Name: "Singapore Dollar", DecimalPlaces: 2}
 	XSU = CurrencyCode{Code: "XSU", NumericCode: "994", Name: "Sucre", DecimalPlaces: 0}
+	XAD = CurrencyCode{Code: "XAD", NumericCode: "396", Name: "Arab Accounting Dinar", DecimalPlaces: 2}
 	SBD = CurrencyCode{Code: "SBD", NumericCode: "090", Name: "Solomon Islands Dollar", DecimalPlaces: 2}
 	SOS = CurrencyCode{Code: "SOS", NumericCode: "706", Name: "Somali Shilling", DecimalPlaces: 2}
 	SSP = CurrencyCode{Code: "SSP", NumericCode: "728", Name: "South Sudanese Pound", DecimalPlaces: 2}
@@ -201,6 +204,7 @@ var (
 	UZS = CurrencyCode{Code: "UZS", NumericCode: "860", Name: "Uzbekistan Sum", DecimalPlaces: 2}
 	VUV = CurrencyCode{Code: "VUV", NumericCode: "548", Name: "Vatu", DecimalPlaces: 0}
 	VES = CurrencyCode{Code: "VES", NumericCode: "928", Name: "Bolívar Soberano", DecimalPlaces: 2}
+	VED = CurrencyCode{Code: "VED", NumericCode: "926", Name: "Bolívar Soberano", DecimalPlaces: 2}
 	VND = CurrencyCode{Code: "VND", NumericCode: "704", Name: "Dong", DecimalPlaces: 0}
 	YER = CurrencyCode{Code: "YER", NumericCode: "886", Name: "Yemeni Rial", DecimalPlaces: 2}
 	ZMW = CurrencyCode{Code: "ZMW", NumericCode: "967", Name: "Zambian Kwacha", DecimalPlaces: 2}
@@ -317,8 +321,9 @@ var lookupTable = map[string]CurrencyCode{
 	"192": CUP, // Cuban Peso
 	"CUC": CUC, // Peso Convertible
 	"931": CUC, // Peso Convertible
-	"ANG": ANG, // Netherlands Antillean Guilder
-	"532": ANG, // Netherlands Antillean Guilder
+	"ANG": ANG, // Netherlands Antillean Guilder (withdrawn; succeeded by XCG)
+	"XCG": XCG, // Caribbean Guilder
+	"532": XCG, // Caribbean Guilder (532 reassigned from the withdrawn ANG)
 	"CZK": CZK, // Czech Koruna
 	"203": CZK, // Czech Koruna
 	"DKK": DKK, // Danish Krone
@@ -489,10 +494,14 @@ var lookupTable = map[string]CurrencyCode{
 	"690": SCR, // Seychelles Rupee
 	"SLL": SLL, // Leone
 	"694": SLL, // Leone
+	"SLE": SLE, // Leone
+	"925": SLE, // Leone
 	"SGD": SGD, // Singapore Dollar
 	"702": SGD, // Singapore Dollar
 	"XSU": XSU, // Sucre
 	"994": XSU, // Sucre
+	"XAD": XAD, // Arab Accounting Dinar
+	"396": XAD, // Arab Accounting Dinar
 	"SBD": SBD, // Solomon Islands Dollar
 	"090": SBD, // Solomon Islands Dollar
 	"SOS": SOS, // Somali Shilling
@@ -551,6 +560,8 @@ var lookupTable = map[string]CurrencyCode{
 	"548": VUV, // Vatu
 	"VES": VES, // Bolívar Soberano
 	"928": VES, // Bolívar Soberano
+	"VED": VED, // Bolívar Soberano
+	"926": VED, // Bolívar Soberano
 	"VND": VND, // Dong
 	"704": VND, // Dong
 	"YER": YER, // Yemeni Rial

--- a/iso4217_test.go
+++ b/iso4217_test.go
@@ -1,0 +1,81 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iso4217_test
+
+import (
+	"testing"
+
+	"github.com/moov-io/iso4217"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Currencies added to the official ISO 4217 List One (active) after the table was
+// last topped up: SLE (Sierra Leone, 2022), VED (Venezuela, 2021), XCG (Curaçao/
+// Sint Maarten, 2025) and XAD (Arab Monetary Fund, 2025). All carry a 2-digit minor
+// unit per List One.
+func TestActiveListOneAdditions(t *testing.T) {
+	cases := []struct {
+		alpha, numeric, name string
+		decimals             uint8
+	}{
+		{"SLE", "925", "Leone", 2},
+		{"VED", "926", "Bolívar Soberano", 2},
+		{"XCG", "532", "Caribbean Guilder", 2},
+		{"XAD", "396", "Arab Accounting Dinar", 2},
+	}
+	for _, tc := range cases {
+		cc, exists := iso4217.Lookup(tc.alpha)
+		assert.Truef(t, exists, "Lookup(%q)", tc.alpha)
+		assert.Equal(t, tc.alpha, cc.Code)
+		assert.Equal(t, tc.numeric, cc.NumericCode)
+		assert.Equal(t, tc.name, cc.Name)
+		assert.Equal(t, tc.decimals, cc.DecimalPlaces)
+	}
+}
+
+// The three non-colliding numeric codes resolve directly to the new currency.
+func TestActiveListOneNumericLookups(t *testing.T) {
+	for numeric, alpha := range map[string]string{"925": "SLE", "926": "VED", "396": "XAD"} {
+		cc, exists := iso4217.Lookup(numeric)
+		assert.Truef(t, exists, "Lookup(%q)", numeric)
+		assert.Equal(t, alpha, cc.Code)
+	}
+}
+
+// XCG replaced ANG and inherited ISO numeric code 532. Numeric 532 resolves to the
+// currently-assigned currency (XCG); the withdrawn ANG stays reachable by its alpha
+// code so historical records still validate.
+func TestNumericCode532IsXCG(t *testing.T) {
+	cc, exists := iso4217.Lookup("532")
+	assert.True(t, exists)
+	assert.Equal(t, "XCG", cc.Code)
+
+	cc, exists = iso4217.Lookup("ANG")
+	assert.True(t, exists)
+	assert.Equal(t, "ANG", cc.Code)
+	assert.Equal(t, "532", cc.NumericCode)
+}
+
+// Withdrawn predecessors are deliberately retained for historical lookups.
+func TestWithdrawnPredecessorsRetained(t *testing.T) {
+	for _, code := range []string{"SLL", "VES", "ANG"} {
+		_, exists := iso4217.Lookup(code)
+		assert.Truef(t, exists, "Lookup(%q)", code)
+	}
+}


### PR DESCRIPTION
Four codes on the current official ISO 4217 List One are missing from the table, so `Lookup` returns `(_, false)` for them:

| Alpha | Numeric | Minor | Name |
|---|---|---|---|
| SLE | 925 | 2 | Leone (Sierra Leone redenomination, 2022; SLL still present but withdrawn) |
| VED | 926 | 2 | Bolívar Soberano (Venezuela digital bolívar, 2021) |
| XCG | 532 | 2 | Caribbean Guilder (Curaçao / Sint Maarten, 2025; replaced ANG) |
| XAD | 396 | 2 | Arab Accounting Dinar (Arab Monetary Fund, Amendment 179, 2025) |

I diffed all 181 existing entries against the official List One (SIX `list_one.xml`), pycountry and CLDR: every present numeric code and minor unit is already correct (KWD/BHD/OMR = 3, CLF/UYW = 4, the francs / JPY / KRW = 0), and these four are the only active codes missing. Retained withdrawn codes (ANG, SLL, HRK, ...) are left untouched.

**XCG / ANG numeric 532 collision.** XCG inherited ANG's numeric code 532. A numeric key can resolve to only one currency, so I mapped `"532" -> XCG` (the currently assigned holder) and kept `ANG` reachable by its alpha code so historical records still validate. If you'd rather keep `"532" -> ANG` and expose XCG by alpha only, that's an easy swap.

This also affects `moov-io/ach`, which validates IAT currency fields through `iso4217.Lookup` (`iatBatchHeader.go`), so a valid batch denominated in SLE/VED/XCG is currently rejected.

Same shape as the ZWG (v0.3.1) and CNH (v0.3.2) additions.