### PR TITLE
ci: use Go stable in GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: '>= 1.20.4'
+        go-version: stable
       id: go
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
Use `go-version: stable` in `.github/workflows/go.yml` so CI follows newer Go releases instead of staying on `>= 1.20.4`.